### PR TITLE
Support 'doctype 5'

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,9 @@ XHTML DOCTYPES
     doctype html
       <!DOCTYPE html>
 
+    doctype 5
+      <!DOCTYPE html>
+
     doctype 1.1
       <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
         "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">

--- a/lib/html/fast.js
+++ b/lib/html/fast.js
@@ -34,6 +34,7 @@ FastProto.on_html_doctype = function(exps) {
 
   var XHTML_DOCTYPES = {
     '1.1'          : '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">',
+    '5'            : '<!DOCTYPE html>',
     'html'         : '<!DOCTYPE html>',
     'strict'       : '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">',
     'frameset'     : '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd">',
@@ -43,6 +44,7 @@ FastProto.on_html_doctype = function(exps) {
   }
 
   var HTML_DOCTYPES = {
+    '5'            : '<!DOCTYPE html>',
     'html'         : '<!DOCTYPE html>',
     'strict'       : '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">',
     'frameset'     : '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" "http://www.w3.org/TR/html4/frameset.dtd">',

--- a/test/html/fast.js
+++ b/test/html/fast.js
@@ -23,7 +23,7 @@ suite('Fast', function() {
     );
 
     assert.deepEqual(
-      filter.exec(['multi', ['html', 'doctype', 'html']]),
+      filter.exec(['multi', ['html', 'doctype', '5']]),
       ['multi', ['static', '<!DOCTYPE html>']]
     );
 


### PR DESCRIPTION
**Slim** supports not only `doctype html` but also `doctype 5` for `<!DOCTYPE html>`. Let's **Slm** does so too!
###### References:
1. http://rdoc.info/gems/slim/file/README.md#Doctype_tag
2. https://github.com/judofyr/temple/blob/master/lib/temple/html/fast.rb#L7
