### PR TITLE
New function expressOpts(options) allows options parameter in ExpressJS

### DIFF
--- a/lib/slm.js
+++ b/lib/slm.js
@@ -40,3 +40,12 @@ slm.__express = function(path, options, fn) {
   });
 };
 
+/*
+  This allows us to pass ExpressJS some options
+  Note: Should only be used to initialise Slm.
+*/
+slm.expressOpts = function(options) {
+  template = new Template(require('./vm_node'), options);
+  slm = template.exports();
+  return this.__express;
+}

--- a/lib/template.js
+++ b/lib/template.js
@@ -15,10 +15,8 @@ var StaticMerger = require('./filters/static_merger');
 var StringGenerator = require('./generators/string');
 
 function Template(VM, options) {
-
-  options = options || {
-    mergeAttrs: { 'class': ' ' }
-  };
+  options = options || {}
+  options.mergeAttrs = options.mergeAttrs || { 'class': ' ' }
 
   this.VM = VM;
   this._engine = new Engine();


### PR DESCRIPTION
This function allows us to pass an options parameter to Slm while using ExpressJS

Example Usage

    app.engine('slm', require('slm').expressOpts({
      format: 'html'
    });
    app.set 'view engine', 'slm'

This fixes Issue #14 - and also exposes and fixes an issue in template.js - Issue #16 
After merging, I would suggest you check where options.mergeAttrs was failing (Stack Trace @ #16)