### PR TITLE
Add link to Webpack slm-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ HAML -> Jade -> Slim -> Slm
 * Gulp: <https://github.com/simnalamburt/gulp-slm>
 * Grunt: <https://github.com/MichaelDanilov/grunt-slm>
 * Karma: <https://github.com/looker/karma-slm-preprocessor>
+* Webpack: <https://github.com/wealthbar/slm-loader>
 
 ### How to start?
 


### PR DESCRIPTION
Adds a link to the Webpack slm-loader project on Github

I recently switched from Rails/Sprockets to Webpack and am using SLM to maintain compatibility with our old SLIM templates. This is the webpack loader we use. It has been published to NPM.