### PR TITLE
Mixins

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,17 @@ Even with default values:
     .say
       = mixin('paragraph')
 
+And from `partial`:
+
+    // mixins.slm
+    = mixin('paragraph', 'name = me')
+      p Hello from ${this.name}!
+
+    // index.slm
+    = partial('mixins')
+    .say
+      = mixin('paragraph')
+
 # License
 
 Slm is released under the [MIT license](http://www.opensource.org/licenses/MIT).

--- a/README.md
+++ b/README.md
@@ -471,6 +471,31 @@ To escape the interpolation (i.e. render as is)
     body
       h1 Welcome \${current_user.name} to the show.
 
+## Mixins
+
+Mixins allow you to create reusable blocks of Slm.
+
+    = mixin('paragraph')
+      p Hello from mixin!
+
+    .say
+      = mixin('paragraph')
+
+They are compiled to functions and can take arguments:
+
+    = mixin('paragraph', 'name')
+      p Hello from ${this.name}!
+
+    .say
+      = mixin('paragraph', 'me')
+
+Even with default values:
+
+    = mixin('paragraph', 'name = me')
+      p Hello from ${this.name}!
+
+    .say
+      = mixin('paragraph')
 
 # License
 

--- a/lib/template.js
+++ b/lib/template.js
@@ -103,7 +103,7 @@ p.src = function(src, options) {
   return [
     '[function(vm) {',
     'vm.m = this;',
-    'var sp = vm.stack.length, require = vm.require, content = vm._content, extend = vm._extend, partial = vm._partial, j = vm.j;',
+    'var sp = vm.stack.length, require = vm.require, content = vm._content, extend = vm._extend, partial = vm._partial, mixin = vm._mixin, j = vm.j;',
     this._engine.exec(src, options),
     'vm.res=_b;return vm.pop(sp);}]'
   ].join('');

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -37,7 +37,7 @@ function escape(str) {
     str = str.toString();
   }
 
-  if (escapeRe.test(str) ) {
+  if (escapeRe.test(str)) {
     if (str.indexOf('&') !== -1) {
       str = str.replace(ampRe, '&amp;');
     }
@@ -69,7 +69,7 @@ function rejectEmpty(arr) {
 }
 
 function flatten(arr) {
-  return arr.reduce(function (acc, val) {
+  return arr.reduce(function(acc, val) {
     if (val === null) {
       return acc;
     }
@@ -105,6 +105,7 @@ VMProto.rebind = function() {
   this._content = this.content.bind(this);
   this._extend = this.extend.bind(this);
   this._partial = this.partial.bind(this);
+  this._mixin = this.mixin.bind(this);
 };
 
 VMProto._loadWithCache = function(path) {
@@ -124,6 +125,7 @@ VMProto._load = VMProto._loadWithCache;
 */
 VMProto.reset = function() {
   this._contents = {};
+  this._mixins = {};
   this.res = '';
   this.stack = [];
   this.m = null;
@@ -201,5 +203,103 @@ VMProto.content = function() {
       }
   }
 };
+
+VMProto.mixin = function() {
+  var name = arguments[0];
+
+  var lastArgument = arguments[arguments.length - 1];
+  if (typeof lastArgument === 'function') { // mixin definition
+    var cb = lastArgument;
+
+    // make Mixin parameters from definition
+    var args = [];
+    for (var i = 1; i < arguments.length - 1; i++) {
+      var param = arguments[i];
+      var defaultValue = null;
+
+      // check the default value [= mixin("name", "a=1", "b=2", "c")]
+      var m = param.match(/([^\=\s]*)\s*\=\s*(.*)/);
+      if (m) {
+        param = m[1];
+        defaultValue = m[2];
+      }
+
+      args.push({
+        name: param,
+        value: defaultValue
+      });
+    }
+
+    if (name) {
+      this._mixins[name] = {
+        arguments: args,
+        body: cb
+      };
+      return '';
+    }
+    return '';
+  }
+
+  // mixin reference
+  var referenceParams = [];
+  for (var i = 1; i < arguments.length; i++) {
+    referenceParams.push(arguments[i]);
+  }
+
+  // Try to find mixin
+  var mixin = null;
+  for (var item in this._mixins) {
+    // Check Mixin name
+    if (item === item) {
+      var maybeMixin = this._mixins[item];
+
+      //Check balance of arguments. If Mixin has free parameters without default values then skip this Mixin
+      var paramsLength = maybeMixin.arguments.length;
+      var mixinStatus = true;
+      for (var i = referenceParams.length; i < maybeMixin.arguments.length; i++) {
+        var param = maybeMixin.arguments[i];
+
+        if (!param.value) {
+          mixinStatus = false;
+          break;
+        }
+      }
+
+      if (mixinStatus) {
+        mixin = maybeMixin;
+        break;
+      }
+    }
+  }
+
+  if (!mixin) {
+    return '';
+  }
+
+  // Add default values
+  var mixinParams = mixin.arguments;
+  if (referenceParams.length !== mixinParams.length) {
+    for (var i = referenceParams.length; i < mixinParams.length; i++) {
+      if (mixinParams[i]) {
+        referenceParams.push(mixinParams[i].value);
+      }
+    }
+  }
+
+  // Convert Array to Object
+  var params = {};
+  for (var i = 0; i < referenceParams.length; i++) {
+    params[mixinParams[i].name] = referenceParams[i];
+  }
+
+  // Merge Mixin params with context
+  if (this.m) {
+    for (var item in this.m) {
+      params[item] = this.m[item];
+    }
+  }
+
+  return mixin.body.call(params);
+}
 
 module.exports = VM;

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -217,7 +217,7 @@ VMProto.mixin = function() {
       var param = arguments[i];
       var defaultValue = null;
 
-      // check the default value [= mixin("name", "a=1", "b=2", "c")]
+      // check the default value [= mixin("name", "a=1", "b = 2", "c")]
       var m = param.match(/([^\=\s]*)\s*\=\s*(.*)/);
       if (m) {
         param = m[1];
@@ -246,14 +246,14 @@ VMProto.mixin = function() {
     referenceParams.push(arguments[i]);
   }
 
-  // Try to find mixin
+  // try to find mixin
   var mixin = null;
   for (var item in this._mixins) {
     // Check Mixin name
-    if (item === item) {
+    if (item === name) {
       var maybeMixin = this._mixins[item];
 
-      //Check balance of arguments. If Mixin has free parameters without default values then skip this Mixin
+      // check balance of arguments. If Mixin has free parameters without default values then skip this Mixin
       var paramsLength = maybeMixin.arguments.length;
       var mixinStatus = true;
       for (var i = referenceParams.length; i < maybeMixin.arguments.length; i++) {
@@ -276,7 +276,7 @@ VMProto.mixin = function() {
     return '';
   }
 
-  // Add default values
+  // add default values
   var mixinParams = mixin.arguments;
   if (referenceParams.length !== mixinParams.length) {
     for (var i = referenceParams.length; i < mixinParams.length; i++) {
@@ -286,13 +286,13 @@ VMProto.mixin = function() {
     }
   }
 
-  // Convert Array to Object
+  // convert Array to Object
   var params = {};
   for (var i = 0; i < referenceParams.length; i++) {
     params[mixinParams[i].name] = referenceParams[i];
   }
 
-  // Merge Mixin params with context
+  // merge Mixin params with context
   if (this.m) {
     for (var item in this.m) {
       params[item] = this.m[item];

--- a/package.json
+++ b/package.json
@@ -22,16 +22,13 @@
     "gulp": "^3.8.11",
     "gulp-concat": "^2.5.2",
     "gulp-gzip": "^1.0.0",
-    "gulp-load-plugins": "^1.0.0",
+    "gulp-load-plugins": "^1.2.2",
     "gulp-replace": "^0.5.3",
-    "gulp-size": "^2.0.0",
+    "gulp-size": "^2.1.0",
     "gulp-uglify": "^2.0.0",
     "gulp-util": "^3.0.4",
     "gulp-webpack": "^1.3.0",
-    "lab": "^11.0.0",
-    "gulp-load-plugins": "^1.2.2",
-    "gulp-size": "^2.1.0",
-    "gulp-uglify": "^1.5.3"
+    "lab": "^11.0.0"
   },
   "directories": {
     "test": "test"

--- a/test/core/code_structure.js
+++ b/test/core/code_structure.js
@@ -226,6 +226,107 @@ lab.experiment('Code structure', function() {
       {}, done);
   });
 
+  lab.test('simple mixin', function(done) {
+    assertHtml(template, [
+      '= mixin("say", "a", "b")',
+      '  p Hello ${this.a} by ${this.b}',
+      '.hello',
+      '  = mixin("say", "Slm", "mixin")'
+      ],
+      '<div class="hello"><p>Hello Slm by mixin</p></div>',
+      {}, done);
+  });
+
+  lab.test('mixin with loop', function(done) {
+    assertHtml(template, [
+      '= mixin("say", "list")',
+      '  ul',
+      '    - this.list.forEach(function(item))',
+      '      li = item.name',
+      '.hello',
+      '  = mixin("say", [{ name: "a" }, { name: "b" }])'
+      ],
+      '<div class="hello"><ul><li>a</li><li>b</li></ul></div>',
+      {}, done);
+  });
+
+  lab.test('mixin with content', function(done) {
+    assertHtml(template, [
+      '= content("myContent")',
+      '  p Hello from mixin!',
+      '= mixin("say", "listOfItems")',
+      '  = content("myContent")',
+      '  ul',
+      '    - this.listOfItems.forEach(function(item))',
+      '      li = item.name',
+      '.hello',
+      '  = mixin("say", [{ name: "a" }, { name: "b" }])',
+      '  p ${this.items}'
+      ],
+      '<div class="hello"><p>Hello from mixin!</p><ul><li>a</li><li>b</li></ul><p>1,2,3</p></div>',
+      {}, done);
+  });
+
+  lab.test('mixin with all defaults values', function(done) {
+    assertHtml(template, [
+      '= mixin("say", "a = Slm", "b = mixin")',
+      '  p Hello ${this.a} by ${this.b}',
+      '.hello',
+      '  = mixin("say")'
+      ],
+      '<div class="hello"><p>Hello Slm by mixin</p></div>',
+      {}, done);
+  });
+
+
+  lab.test('mixin with first default value', function(done) {
+    assertHtml(template, [
+      '= mixin("say", "a = Slm", "b")',
+      '  p Hello ${this.a} by ${this.b}',
+      '.hello',
+      '  = mixin("say", "Mom")'
+      ],
+      '<div class="hello"></div>',
+      {}, done);
+  });
+
+  lab.test('mixin with second default value', function(done) {
+    assertHtml(template, [
+      '= mixin("say", "a", "b= mixin")',
+      '  p Hello ${this.a} by ${this.b}',
+      '.hello',
+      '  = mixin("say", "Mom")'
+      ],
+      '<div class="hello"><p>Hello Mom by mixin</p></div>',
+      {}, done);
+  });
+
+  lab.test('mixin with contexts', function(done) {
+    var VM = template.VM;
+    var vm = new VM();
+    vm.resetCache();
+
+    var compileOptions = {
+      basePath: '/',
+      filename: 'mixins.slm'
+    };
+
+    vm.cache(compileOptions.filename, template.exec([
+      '= mixin("say", "a", "b")',
+      '  p Hello ${this.a} by ${this.b}'
+    ].join('\n'), compileOptions, vm));
+
+    var src = [
+      '= partial("mixins.slm")',
+      '.hello',
+      '  = mixin("say", "Slm", "mixin")'
+    ].join('\n');
+
+    var result = template.render(src, {}, compileOptions, vm);
+    assert.deepEqual(result, '<div class="hello"><p>Hello Slm by mixin</p></div>');
+    done();
+  });
+
   lab.test('render with forEach', function(done) {
     assertHtml(template, [
       'div',


### PR DESCRIPTION
Source: #35 

Well, my vision of Mixin support in Slm. Please, read documentation and review my code.

## Mixins

Mixins allow you to create reusable blocks of Slm.

    = mixin('paragraph')
      p Hello from mixin!

    .say
      = mixin('paragraph')

They are compiled to functions and can take arguments:

    = mixin('paragraph', 'name')
      p Hello from ${this.name}!

    .say
      = mixin('paragraph', 'me')

Even with default values:

    = mixin('paragraph', 'name = me')
      p Hello from ${this.name}!

    .say
      = mixin('paragraph')

And from `partial`:

    // mixins.slm
    = mixin('paragraph', 'name = me')
      p Hello from ${this.name}!

    // index.slm
    = partial('mixins')
    .say
      = mixin('paragraph')